### PR TITLE
correct configure requires specification

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -19,7 +19,7 @@ my $builder = Alien::Base::ModuleBuild->new(
   license => 'perl',
   configure_requires => {
     'Module::Build' => 0.42,
-    'Alien::Base' => 0.021,
+    'Alien::Base::ModuleBuild' => 0.021,
   },
   requires => {
     'perl' => '5.8.1',


### PR DESCRIPTION
Technically the configure dependency is on `Alien::Base::ModuleBuild`.  This change will future proof this module when/if AB::MB is split from the rest of AB.  For the rationale for this see:

https://github.com/Perl5-Alien/Alien-Base/issues/157
